### PR TITLE
v1.13.0 release information to match major.minor to tensorflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # TensorFlow iOS Framework
 
-A full build version of TensorFlow for iOS. Unofficial. Based on Tensorflow Build: 1.13rc2
+A full build of TensorFlow for iOS. Unofficial. Latest is v1.13.0 based on Tensorflow 1.13rc2
 
-Framework version is 0.3.0 targeting arm64 devices only (iOS 12.0+) with full support for training MobileNet models on device.
+Framework targets simluator and arm64 devices only (iOS 12.0+) with full support for training MobileNetV2 models on device.
 
 ## Notes
 

--- a/download_libs.sh
+++ b/download_libs.sh
@@ -1,15 +1,26 @@
 #! /bin/sh
 
 TENSORIO_BUILD_URL=https://storage.googleapis.com/tensorio-build/
-LIB_TENSORFLOW_URL=$TENSORIO_BUILD_URL/tensorflow
+
+
+# ordered newest to oldest
+
+TENSORFLOW_1_13_0=tensorflow_1_13_0     # begin new version scheme, identifical to 0.3
+TENSORFLOW_0_3=tensorflow_0.3.0         # last 0.x version
+
+
+LIB_TENSORFLOW_URL=$TENSORIO_BUILD_URL/$TENSORFLOW_1_13_0
 # LIB_PROTOBUF_URL=$TENSORIO_BUILD_URL/libprotobuf
 # LIB_NSYNC_URL=$TENSORIO_BUILD_URL/nsync
+
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FRAMEWORK_DIR=tensorflow.framework
 
+
 echo "Downloading tensorflow static lib to $FRAMEWORK_DIR/tensorflow"
 cd $SCRIPT_DIR/$FRAMEWORK_DIR
 curl -O $LIB_TENSORFLOW_URL
+
 
 echo "Download complete"


### PR DESCRIPTION
Rationalizing tags and releases.

From this point on major.minor will correspond to the major.minor of the build of tensorflow the framework contains while the patch will correspond to our own changes to the build, usually to include ops for additional model support.