### PR TITLE
R1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Framework targets simluator and arm64 devices only (iOS 12.0+) with full support
 
 ## Notes
 
-This repository contains only the required header files for a portable build of tensorflow for ios. The tensorflow static library must be added to the root directory of the framework.
+This repository contains only the required header files for a portable build of tensorflow for iOS. The tensorflow static library must be added to the root directory of the framework.
 
 To create this framework, first run *build_all_ios.sh* from *tensorflow/contrib/makefile* on branch *r1.15.doc.ai* in our custom [tensorflow repository](https://github.com/doc-ai/tensorflow/tree/r1.15.doc.ai) and then run *create_full_ios_frameworks.sh* in the same directory.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TensorFlow iOS Framework
 
-A full build of TensorFlow for iOS. Unofficial. Latest is v1.15 based on Tensorflow r1.15.
+A full build of TensorFlow for iOS. Unofficial. Latest is v1.15.1 based on Tensorflow r1.15.
 
 Framework targets simluator and arm64 devices only (iOS 12.0+) with full support for training MobileNetV2 models on device.
 

--- a/download_libs.sh
+++ b/download_libs.sh
@@ -5,10 +5,11 @@ TENSORIO_BUILD_URL=https://storage.googleapis.com/tensorio-build/r1.15
 # ordered newest to oldest
 # library is stored on google with name tensorflow_tf.version_our.version
 
+TENSORFLOW_1_15_1=tensorflow_1.15_1     # adds _FusedMatMul op
 TENSORFLOW_1_15_0=tensorflow_1.15_0     # initial 1.15 build
 
 
-LIB_TENSORFLOW_URL=$TENSORIO_BUILD_URL/$TENSORFLOW_1_15_0
+LIB_TENSORFLOW_URL=$TENSORIO_BUILD_URL/$TENSORFLOW_1_15_1
 # LIB_PROTOBUF_URL=$TENSORIO_BUILD_URL/libprotobuf
 # LIB_NSYNC_URL=$TENSORIO_BUILD_URL/nsync
 


### PR DESCRIPTION
Adds an op needed to support one of our TF 2.0 examples. Will tag 1.15.1 and release via our cocoapod.